### PR TITLE
ci: add Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,41 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Detect the language and stack from the repository, then review this
+            pull request with a focus on:
+            - Code quality and idioms appropriate to the detected stack
+            - Architecture and design patterns; respect existing layer boundaries
+            - Potential bugs, race conditions, null safety, and edge cases
+            - Security implications (input validation, secrets, auth)
+            - Performance considerations
+            - Test coverage where applicable
+
+            Provide detailed feedback using inline comments for specific issues.
+            Skip nitpicks; focus on issues that materially affect correctness,
+            security, or maintainability.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- Adds Claude Code Action v1 workflow for auto PR reviews
- Uses `CLAUDE_CODE_OAUTH_TOKEN` secret (subscription-based, no per-PR cost)
- Triggers on PR opened/synchronize/ready_for_review/reopened

## Test plan
- [ ] Merge this PR
- [ ] Confirm Claude posts review comment on the next PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new PR-triggered GitHub Action that runs with `pull-requests: write` and uses a repository secret (`CLAUDE_CODE_OAUTH_TOKEN`), so misconfiguration could affect PR comment permissions and secret exposure boundaries.
> 
> **Overview**
> Introduces a new `.github/workflows/claude-code-review.yml` workflow that triggers on key PR events and runs `anthropics/claude-code-action@v1` after checkout.
> 
> The job is granted `pull-requests: write` (plus `contents: read` and `id-token: write`), uses the `CLAUDE_CODE_OAUTH_TOKEN` secret, and constrains the action via `claude_args` to specific PR-comment/diff/view tools while providing a review-focused prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e60864a084a76b27c3cd0f10f7044be0243fb37b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->