### PR TITLE
ci: skip Claude review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   review:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Skip the Claude Code Review job for Dependabot-authored PRs.
- Keep human-authored PR review behavior unchanged.

## Why
Dependabot PRs were triggering the Claude Code Action and failing before any review was posted because the action blocks non-human actors by default. This leaves a red `review` check without useful feedback.

## Test Plan
- Parsed `.github/workflows/claude-code-review.yml` as YAML locally.
- Verified the diff only adds a job-level Dependabot actor guard.
