### PR TITLE
fix: ITT-746 protobufjs 보안 dependency 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
       "ajv": "^6.14.0",
       "diff": "^4.0.4",
       "minimatch": ">=3.1.3",
-      "protobufjs": ">=7.5.5",
+      "protobufjs": ">=8.6.0",
       "picomatch": ">=4.0.4",
       "brace-expansion@1": ">=1.1.13",
       "brace-expansion@2": ">=2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   ajv: ^6.14.0
   diff: ^4.0.4
   minimatch: '>=3.1.3'
-  protobufjs: '>=7.5.5'
+  protobufjs: '>=8.6.0'
   picomatch: '>=4.0.4'
   brace-expansion@1: '>=1.1.13'
   brace-expansion@2: '>=2.0.3'
@@ -5162,10 +5162,10 @@ packages:
         integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==,
       }
 
-  protobufjs@8.4.2:
+  protobufjs@8.6.4:
     resolution:
       {
-        integrity: sha512-64rfNzkWOZAIazXzpBFPWq6F9up6gMvTzjE2oWIzApx2N/dqVUEE7+bCn2+40780dFVtKOUab8QfxJ6KJDWbqA==,
+        integrity: sha512-/+XMv9JalknuncEJSwsyEVlwcxVLKx2iaoSUXFZA86MJkdqyOdfrlB1sB7S6aKyUk9tl20YY+SgQe5J2sJHTcg==,
       }
     engines: { node: '>=12.0.0' }
 
@@ -6697,7 +6697,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 8.4.2
+      protobufjs: 8.6.4
       yargs: 17.7.2
 
   '@heroicons/react@2.2.0(react@19.2.7)':
@@ -7232,7 +7232,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
-      protobufjs: 8.4.2
+      protobufjs: 8.6.4
 
   '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9819,7 +9819,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@8.4.2:
+  protobufjs@8.6.4:
     dependencies:
       long: 5.3.2
 


### PR DESCRIPTION
## 요약
- `pnpm.overrides.protobufjs`를 `>=8.6.0`으로 올렸습니다.
- `pnpm-lock.yaml`의 transitive `protobufjs` resolution/reference를 `8.6.4`로 갱신했습니다.
- 변경 범위는 `package.json`, `pnpm-lock.yaml`의 `protobufjs` 보안 alert 해소용 최소 dependency fix로 제한했습니다.

## 검증
- `gh run view 27569933575 --repo get6/get6.github.io --json status,conclusion,headSha,displayTitle,createdAt,updatedAt,url`
- `gh run view 27602949986 --repo get6/get6.github.io --json status,conclusion,headSha,displayTitle,createdAt,updatedAt,url`
- `gh api "repos/get6/get6.github.io/dependabot/alerts?state=open&per_page=100"`: default branch 기준 `protobufjs` alert `#74`, `#75`는 PR merge 전이라 아직 open입니다.
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm list protobufjs --depth 20`: `@grpc/proto-loader`, `@opentelemetry/otlp-transformer` 경로가 모두 `protobufjs 8.6.4`입니다.
- `pnpm lint`: exit 0, 기존 `@next/next/no-img-element` warning 5개만 확인했습니다.
- `pnpm build`: exit 0, static generation `685/685` 완료했습니다.
- `pnpm audit --prod --json`: exit 1, `protobufjs` advisory는 사라졌고 범위 밖 `js-yaml`, `@opentelemetry/core` moderate advisory만 남았습니다.
- `git diff --check`

Closes ITT-746
Refs ITT-690
