### PR TITLE
ci: 로컬 self-hosted runner 사용

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   review:
     if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, get6]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   automerge:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, get6]
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, get6]
     strategy:
       matrix:
         node-version: [22.x]
@@ -83,7 +83,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, get6]
     needs: build
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## 변경 내용

- GitHub Actions workflow의 `runs-on`을 로컬 self-hosted runner label로 변경했습니다.
- `ittae` repo는 `[self-hosted, ittae]`, `get6` repo는 `[self-hosted, get6]`를 사용합니다.

## 검증

- 변경 후 workflow YAML 파싱 검증 통과
- `ubuntu-latest` / `macos-latest` runs-on 잔여 없음 확인
- 로컬 runner GitHub API 상태 `online`, `busy=false` 확인

## 리스크 / 롤백

- self-hosted runner 환경 의존성이 생깁니다. 로컬 Mac mini의 toolchain, Docker, secret 접근 권한에 따라 기존 GitHub-hosted runner와 동작 차이가 있을 수 있습니다.
- 롤백은 이 PR을 닫거나 `runs-on` 값을 기존 GitHub-hosted runner로 되돌리면 됩니다.
