### PR TITLE
ci: get6 workflows use hosted runners

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   review:
     if: github.actor != 'dependabot[bot]'
-    runs-on: [self-hosted, get6]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   automerge:
-    runs-on: [self-hosted, get6]
+    runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: [self-hosted, get6]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [22.x]
@@ -83,7 +83,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: [self-hosted, get6]
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## 변경 내용

- get6 repo에서는 local self-hosted action runner를 사용하지 않도록 `runs-on`을 `ubuntu-latest`로 되돌립니다.

## 이유

- 로컬 runner가 내부/T7 디스크 용량을 계속 차지하므로 get6 repo는 GitHub-hosted runner로 처리합니다.

## 검증

- workflow YAML patch lint 통과.
