### PR TITLE
fix: ITT-1291 copy-dir 이미지 처리 완료 대기

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "npx serve@latest out",
     "lint": "eslint . --ext .ts,.tsx",
     "copy-dir": "ts-node scripts/copy-image.ts",
+    "test:copy-image": "ts-node scripts/copy-image.test.ts",
     "copy-fonts": "ts-node scripts/copy-pretendard.ts",
     "predev": "pnpm copy-dir && pnpm copy-fonts",
     "prebuild": "pnpm copy-dir && pnpm copy-fonts",

--- a/scripts/copy-image.test.ts
+++ b/scripts/copy-image.test.ts
@@ -1,9 +1,14 @@
 import assert from 'assert'
+import fs from 'fs'
+import os from 'os'
 import path from 'path'
+import sharp from 'sharp'
 
-import { getCopyPath } from './copy-image'
+import { getCopyPath, processImages } from './copy-image'
 
-const targetDir = path.resolve('/tmp', 'copy-image-output')
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'copy-image-test-'))
+const sourceDir = path.join(tempRoot, 'source')
+const targetDir = path.join(tempRoot, 'target')
 
 assert.strictEqual(
   getCopyPath('sample.png', targetDir),
@@ -22,4 +27,44 @@ assert.strictEqual(
   path.resolve(targetDir, 'sample.webp'),
 )
 
-console.log('copy-image path conversion tests passed')
+const run = async () => {
+  try {
+    fs.mkdirSync(sourceDir)
+    fs.writeFileSync(path.join(sourceDir, 'notes.txt'), 'not an image')
+
+    await sharp({
+      create: {
+        width: 1,
+        height: 1,
+        channels: 3,
+        background: '#ffffff',
+      },
+    })
+      .png()
+      .toFile(path.join(sourceDir, 'sample.PNG'))
+
+    const result = await processImages(sourceDir, targetDir)
+    const outputPath = path.join(targetDir, 'sample.webp')
+
+    assert.deepStrictEqual(result.processedFiles, ['sample.PNG'])
+    assert.deepStrictEqual(result.skippedFiles, [])
+    assert.strictEqual(fs.existsSync(outputPath), true)
+
+    const metadata = await sharp(outputPath).metadata()
+    assert.strictEqual(metadata.format, 'webp')
+
+    await assert.rejects(
+      () => processImages(path.join(tempRoot, 'missing'), targetDir),
+      /Source image directory does not exist/,
+    )
+
+    console.log('copy-image tests passed')
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+}
+
+run().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/copy-image.test.ts
+++ b/scripts/copy-image.test.ts
@@ -1,0 +1,25 @@
+import assert from 'assert'
+import path from 'path'
+
+import { getCopyPath } from './copy-image'
+
+const targetDir = path.resolve('/tmp', 'copy-image-output')
+
+assert.strictEqual(
+  getCopyPath('sample.png', targetDir),
+  path.resolve(targetDir, 'sample.webp'),
+)
+assert.strictEqual(
+  getCopyPath('sample.JPG', targetDir),
+  path.resolve(targetDir, 'sample.webp'),
+)
+assert.strictEqual(
+  getCopyPath('sample.jpeg', targetDir),
+  path.resolve(targetDir, 'sample.webp'),
+)
+assert.strictEqual(
+  getCopyPath('sample.webp', targetDir),
+  path.resolve(targetDir, 'sample.webp'),
+)
+
+console.log('copy-image path conversion tests passed')

--- a/scripts/copy-image.ts
+++ b/scripts/copy-image.ts
@@ -12,41 +12,64 @@ const copyImage = async (src: string, dest: string) => {
 
 const shouldUpdateImage = (srcPath: string, destPath: string): boolean => {
   if (!fs.existsSync(destPath)) return true
-  
+
   const srcStat = fs.statSync(srcPath)
   const destStat = fs.statSync(destPath)
-  
+
   return srcStat.mtime > destStat.mtime
 }
 
 const srcDir = path.resolve(__dirname, '..', 'blog', 'assets')
 const destDir = path.resolve(__dirname, '..', 'public', 'blog', 'assets')
 
-if (!fs.existsSync(destDir)) {
-  fs.mkdirSync(destDir, { recursive: true })
-}
+const imageFilePattern = /\.(PNG|JPG|JPEG|WEBP|png|jpg|jpeg|webp)$/
+const convertibleImagePattern = /\.(PNG|JPG|JPEG|png|jpg|jpeg)$/
 
-const processedFiles: string[] = []
-const skippedFiles: string[] = []
+export const getCopyPath = (file: string, targetDir = destDir) =>
+  path.resolve(targetDir, file).replace(convertibleImagePattern, '.webp')
 
-fs.readdirSync(srcDir).forEach(async (file) => {
-  const imagePath = path.resolve(srcDir, file)
-  const stat = fs.statSync(imagePath)
-  
-  if (stat.isFile() && /\.(PNG|JPG|JPEG|WEBP|png|jpg|jpeg|webp)$/.test(file)) {
-    const copyPath = path
-      .resolve(destDir, file)
-      .replace(/\.(PNG|JPG|JPEG|png|jpg|jpeg)$/, '.webp')
-    
-    if (shouldUpdateImage(imagePath, copyPath)) {
-      await copyImage(imagePath, copyPath)
-      processedFiles.push(file)
-    } else {
-      skippedFiles.push(file)
+export const processImages = async (
+  sourceDir = srcDir,
+  targetDir = destDir,
+) => {
+  if (!fs.existsSync(targetDir)) {
+    fs.mkdirSync(targetDir, { recursive: true })
+  }
+
+  const processedFiles: string[] = []
+  const skippedFiles: string[] = []
+
+  for (const file of fs.readdirSync(sourceDir)) {
+    const imagePath = path.resolve(sourceDir, file)
+    const stat = fs.statSync(imagePath)
+
+    if (stat.isFile() && imageFilePattern.test(file)) {
+      const copyPath = getCopyPath(file, targetDir)
+
+      if (shouldUpdateImage(imagePath, copyPath)) {
+        await copyImage(imagePath, copyPath)
+        processedFiles.push(file)
+      } else {
+        skippedFiles.push(file)
+      }
     }
   }
-})
 
-console.log(`✅ Images processed: ${processedFiles.length}`)
-console.log(`⏩ Images skipped (up-to-date): ${skippedFiles.length}`)
-console.log('🎉 Image processing completed!')
+  return { processedFiles, skippedFiles }
+}
+
+const main = async () => {
+  const { processedFiles, skippedFiles } = await processImages()
+
+  console.log(`✅ Images processed: ${processedFiles.length}`)
+  console.log(`⏩ Images skipped (up-to-date): ${skippedFiles.length}`)
+  console.log('🎉 Image processing completed!')
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('❌ Image processing failed:')
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/copy-image.ts
+++ b/scripts/copy-image.ts
@@ -22,8 +22,8 @@ const shouldUpdateImage = (srcPath: string, destPath: string): boolean => {
 const srcDir = path.resolve(__dirname, '..', 'blog', 'assets')
 const destDir = path.resolve(__dirname, '..', 'public', 'blog', 'assets')
 
-const imageFilePattern = /\.(PNG|JPG|JPEG|WEBP|png|jpg|jpeg|webp)$/
-const convertibleImagePattern = /\.(PNG|JPG|JPEG|png|jpg|jpeg)$/
+const imageFilePattern = /\.(png|jpe?g|webp)$/i
+const convertibleImagePattern = /\.(png|jpe?g)$/i
 
 export const getCopyPath = (file: string, targetDir = destDir) =>
   path.resolve(targetDir, file).replace(convertibleImagePattern, '.webp')
@@ -32,6 +32,14 @@ export const processImages = async (
   sourceDir = srcDir,
   targetDir = destDir,
 ) => {
+  if (!fs.existsSync(sourceDir)) {
+    throw new Error(`Source image directory does not exist: ${sourceDir}`)
+  }
+
+  if (!fs.statSync(sourceDir).isDirectory()) {
+    throw new Error(`Source image path is not a directory: ${sourceDir}`)
+  }
+
   if (!fs.existsSync(targetDir)) {
     fs.mkdirSync(targetDir, { recursive: true })
   }


### PR DESCRIPTION
## 요약
- `scripts/copy-image.ts`의 async `forEach`를 `processImages()` 기반 `for...of` await 흐름으로 바꿔 이미지 처리 완료 뒤에 count와 완료 로그가 출력되도록 수정했습니다.
- `.png/.jpg/.jpeg` → `.webp` 대상 경로 계산을 `getCopyPath()`로 분리하고 `test:copy-image` regression test를 추가했습니다.
- 기존 `.webp` 유지, mtime 기반 skip, `prebuild`의 `copy-dir` 흐름은 유지했습니다.

## 검증
- `corepack pnpm install --frozen-lockfile`
- 수정 전 재현: asset 291개 상태에서 기존 `corepack pnpm copy-dir`가 `Images processed: 0`, `Images skipped: 0`을 출력했습니다.
- `corepack pnpm test:copy-image`
- `corepack pnpm copy-dir`
- mtime smoke: source 1개 mtime 갱신 후 `processed: 1`, `skipped: 290`; 재실행 후 `processed: 0`, `skipped: 291`
- `find public/blog/assets -maxdepth 1 -type f | wc -l` → `291`
- `corepack pnpm lint` → 통과, 기존 `@next/next/no-img-element` warning 5개
- `corepack pnpm build`

Closes ITT-1291
