### PR TITLE
ITT-1717: 외부 이미지 실패 시 원본 URL fallback

### DIFF
--- a/app/lib/to-local-asset.ts
+++ b/app/lib/to-local-asset.ts
@@ -1,0 +1,60 @@
+import { createHash } from 'crypto'
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import sharp from 'sharp'
+
+type FetchResponse = Pick<Response, 'ok' | 'arrayBuffer'>
+
+type ToLocalAssetOptions = {
+  cacheDir?: string
+  publicImageDir?: string
+  publicUrlPrefix?: string
+  fetcher?: (url: string) => Promise<FetchResponse>
+}
+
+const DEFAULT_CACHE_DIR = '.cache/images'
+const DEFAULT_PUBLIC_IMAGE_DIR = 'public/blog/external'
+const DEFAULT_PUBLIC_URL_PREFIX = '/blog/external'
+
+/**
+ * 외부 이미지를 WebP로 변환해 로컬 asset 경로를 반환한다.
+ * 외부 fetch/body/이미지 변환 실패는 원본 URL로 fallback한다.
+ * 로컬 파일 읽기/쓰기는 빌드 산출물의 정합성 문제이므로 예외를 유지한다.
+ */
+export const toLocalAsset = async (
+  url: string,
+  options: ToLocalAssetOptions = {},
+): Promise<string> => {
+  const cacheDir = options.cacheDir ?? DEFAULT_CACHE_DIR
+  const publicImageDir = options.publicImageDir ?? DEFAULT_PUBLIC_IMAGE_DIR
+  const publicUrlPrefix = options.publicUrlPrefix ?? DEFAULT_PUBLIC_URL_PREFIX
+  const fetcher = options.fetcher ?? fetch
+  const hash = createHash('md5').update(url).digest('hex')
+  const fileName = `${hash}.webp`
+  const cachePath = join(cacheDir, fileName)
+  const publicPath = join(publicImageDir, fileName)
+  const urlPath = `${publicUrlPrefix}/${fileName}`
+
+  if (existsSync(publicPath)) return urlPath
+
+  if (existsSync(cachePath)) {
+    writeFileSync(publicPath, readFileSync(cachePath))
+    return urlPath
+  }
+
+  let buffer: Buffer
+  try {
+    const response = await fetcher(url)
+    if (!response.ok) return url
+
+    buffer = await sharp(await response.arrayBuffer())
+      .webp({ quality: 75 })
+      .toBuffer()
+  } catch {
+    return url
+  }
+
+  writeFileSync(cachePath, buffer)
+  writeFileSync(publicPath, buffer)
+  return urlPath
+}

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -10,16 +10,13 @@ import remarkGfm from 'remark-gfm'
 import remarkLint from 'remark-lint'
 import remarkMath from 'remark-math'
 import remarkToc from 'remark-toc'
-import sharp from 'sharp'
 import { visit } from 'unist-util-visit'
-import { createHash } from 'crypto'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
-import { join } from 'path'
 import { getToC } from './app/lib/toc'
+import { toLocalAsset } from './app/lib/to-local-asset'
+import { existsSync, mkdirSync } from 'fs'
 
 const CACHE_DIR = '.cache/images'
 const PUBLIC_IMAGE_DIR = 'public/blog/external'
-const PUBLIC_URL_PREFIX = '/blog/external'
 const SITE_BASE_URL =
   process.env.NODE_ENV === 'production'
     ? 'https://get6.github.io'
@@ -28,37 +25,6 @@ const SITE_BASE_URL =
 if (!existsSync(CACHE_DIR)) mkdirSync(CACHE_DIR, { recursive: true })
 if (!existsSync(PUBLIC_IMAGE_DIR))
   mkdirSync(PUBLIC_IMAGE_DIR, { recursive: true })
-
-/**
- * 외부 이미지를 webp로 변환해 public/blog/external/<hash>.webp 에 저장하고
- * 사이트 내부 절대 경로(/blog/external/<hash>.webp)를 반환.
- * fetch 실패 시 원본 URL을 반환해 페이지가 깨지지 않도록 한다.
- */
-const toLocalAsset = async (url: string): Promise<string> => {
-  const hash = createHash('md5').update(url).digest('hex')
-  const fileName = `${hash}.webp`
-  const cachePath = join(CACHE_DIR, fileName)
-  const publicPath = join(PUBLIC_IMAGE_DIR, fileName)
-  const urlPath = `${PUBLIC_URL_PREFIX}/${fileName}`
-
-  if (existsSync(publicPath)) return urlPath
-
-  if (existsSync(cachePath)) {
-    writeFileSync(publicPath, readFileSync(cachePath))
-    return urlPath
-  }
-
-  const res = await fetch(url)
-  if (!res.ok) return url
-
-  const buffer = await sharp(await res.arrayBuffer())
-    .webp({ quality: 75 })
-    .toBuffer()
-
-  writeFileSync(cachePath, buffer)
-  writeFileSync(publicPath, buffer)
-  return urlPath
-}
 
 const adjustUl = (node: any, index: number | undefined, parent: any) => {
   if (index === undefined) return

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint . --ext .ts,.tsx",
     "copy-dir": "ts-node scripts/copy-image.ts",
     "test:copy-image": "ts-node scripts/copy-image.test.ts",
+    "test:to-local-asset": "ts-node scripts/to-local-asset.test.ts",
     "test:toc": "ts-node scripts/toc.test.ts",
     "copy-fonts": "ts-node scripts/copy-pretendard.ts",
     "predev": "pnpm copy-dir && pnpm copy-fonts",

--- a/scripts/to-local-asset.test.ts
+++ b/scripts/to-local-asset.test.ts
@@ -1,0 +1,140 @@
+import assert from 'assert'
+import { createHash } from 'crypto'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import sharp from 'sharp'
+
+import { toLocalAsset } from '../app/lib/to-local-asset'
+
+const sourceUrl = 'https://images.example.com/photo.png'
+const fileName = `${createHash('md5').update(sourceUrl).digest('hex')}.webp`
+const toArrayBuffer = (buffer: Buffer): ArrayBuffer =>
+  buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength,
+  ) as ArrayBuffer
+
+const run = async () => {
+  const tempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'to-local-asset-test-'),
+  )
+  const cacheDir = path.join(tempRoot, 'cache')
+  const publicImageDir = path.join(tempRoot, 'public')
+  const publicUrlPrefix = '/external'
+  fs.mkdirSync(cacheDir)
+  fs.mkdirSync(publicImageDir)
+
+  const options = { cacheDir, publicImageDir, publicUrlPrefix }
+
+  try {
+    assert.strictEqual(
+      await toLocalAsset(sourceUrl, {
+        ...options,
+        fetcher: async () => {
+          throw new Error('network unavailable')
+        },
+      }),
+      sourceUrl,
+    )
+
+    assert.strictEqual(
+      await toLocalAsset(sourceUrl, {
+        ...options,
+        fetcher: async () => ({
+          ok: false,
+          arrayBuffer: async () => new ArrayBuffer(0),
+        }),
+      }),
+      sourceUrl,
+    )
+
+    assert.strictEqual(
+      await toLocalAsset(sourceUrl, {
+        ...options,
+        fetcher: async () => ({
+          ok: true,
+          arrayBuffer: async () => {
+            throw new Error('response body unavailable')
+          },
+        }),
+      }),
+      sourceUrl,
+    )
+
+    assert.strictEqual(
+      await toLocalAsset(sourceUrl, {
+        ...options,
+        fetcher: async () => ({
+          ok: true,
+          arrayBuffer: async () =>
+            toArrayBuffer(Buffer.from('<html>not an image</html>')),
+        }),
+      }),
+      sourceUrl,
+    )
+
+    const png = await sharp({
+      create: {
+        width: 2,
+        height: 2,
+        channels: 3,
+        background: '#ffffff',
+      },
+    })
+      .png()
+      .toBuffer()
+
+    let fetchCount = 0
+    const localPath = await toLocalAsset(sourceUrl, {
+      ...options,
+      fetcher: async () => {
+        fetchCount += 1
+        return { ok: true, arrayBuffer: async () => toArrayBuffer(png) }
+      },
+    })
+
+    assert.strictEqual(localPath, `${publicUrlPrefix}/${fileName}`)
+    assert.strictEqual(fetchCount, 1)
+    assert.strictEqual(fs.existsSync(path.join(cacheDir, fileName)), true)
+    assert.strictEqual(fs.existsSync(path.join(publicImageDir, fileName)), true)
+    assert.strictEqual(
+      (await sharp(path.join(publicImageDir, fileName)).metadata()).format,
+      'webp',
+    )
+
+    fs.unlinkSync(path.join(publicImageDir, fileName))
+    const cacheHitPath = await toLocalAsset(sourceUrl, {
+      ...options,
+      fetcher: async () => {
+        throw new Error('cache hit must not fetch')
+      },
+    })
+
+    assert.strictEqual(cacheHitPath, localPath)
+    assert.strictEqual(fs.existsSync(path.join(publicImageDir, fileName)), true)
+
+    await assert.rejects(
+      () =>
+        toLocalAsset('https://images.example.com/write-failure.png', {
+          cacheDir: path.join(tempRoot, 'missing', 'cache'),
+          publicImageDir,
+          publicUrlPrefix,
+          fetcher: async () => ({
+            ok: true,
+            arrayBuffer: async () => toArrayBuffer(png),
+          }),
+        }),
+      /ENOENT/,
+    )
+
+    console.log('to-local-asset tests passed')
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+}
+
+run().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## 요약

- 외부 이미지 fetch, response body 읽기, Sharp 변환 실패 시 원본 URL로 fallback합니다.
- 정상 이미지의 MD5 기반 WebP cache/public 경로와 cache hit 동작은 유지합니다.
- 로컬 파일 읽기/쓰기 오류는 깨진 로컬 경로를 반환하지 않도록 예외를 유지합니다.

## 검증

- `corepack pnpm test:to-local-asset`
- `corepack pnpm test:copy-image`
- `corepack pnpm test:toc`
- `corepack pnpm lint` (기존 `no-img-element` warning 5건, error 0건)
- `corepack pnpm build:content`

Closes ITT-1717
