### PR TITLE
fix: Dependabot major ignore + minor/patch lane

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,50 @@
 version: 2
-updates:
-  # 애플리케이션 의존성. minor/patch는 한 PR로 묶어서 노이즈를 줄이고,
-  # major는 별도 PR로 받아 수동 검토한다.
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: chore(deps)
-    groups:
-      minor-and-patch:
-        update-types:
-          - minor
-          - patch
 
-  # GitHub Actions 버전. 이번 세션에서 한꺼번에 8개 액션을 올렸는데,
-  # 매주 dependabot이 patch 단위로 알려주면 다시 그렇게 밀리지 않는다.
-  - package-ecosystem: github-actions
-    directory: /
+# Policy: ittae workspace policies/dependabot-pr-lanes.md
+# Lane A only: minor/patch version-updates. Majors → Multica/human (never auto-merge).
+# Security updates may still open majors — treat as lane C (human review).
+
+updates:
+  - package-ecosystem: npm
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
       day: monday
+      time: "09:00"
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     commit-message:
-      prefix: ci(deps)
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "automerge-candidate"
     groups:
-      actions:
-        patterns:
-          - '*'
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "automerge-candidate"
+    groups:
+      gha-minor-and-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## 요약
Dependabot이 semver-major version-update PR을 열지 않도록 ignore하고, minor/patch만 그룹으로 받도록 정렬합니다.

## 목표 · 이유
- 현재 open major(#57 TS6, #72 Tailwind4, #73 js-yaml5, #74 @types/node26, #53 ESLint9)는 검증 대상인데, 설정이 major를 계속 열어 lane A와 혼동됨.
- org 정책(`dependabot-pr-lanes.md`): major version-update 금지, minor/patch만 automerge-candidate.

## 변경 사항
- `.github/dependabot.yml`: major ignore, labels, monthly 스케줄, npm/gha minor-patch groups

## 범위 밖
- 기존 open major PR 닫기/머지 (별도 Multica 검증)
- security update major 완전 차단 (GitHub 한계)

## 관련 이슈
Related Multica ITT-1746 / major gates ITT-680, ITT-439

## 위험
- Risk tier: T1
- 기존 open major PR은 수동 정리 필요

## 체크리스트
- [x] major ignore
- [x] labels dependencies + automerge-candidate
