### PR TITLE
fix: Dependabot major는 검토 신호로 유지 (ignore 해제)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,11 @@
 version: 2
 
-# Policy: ittae workspace policies/dependabot-pr-lanes.md
-# Lane A only: minor/patch version-updates. Majors → Multica/human (never auto-merge).
-# Security updates may still open majors — treat as lane C (human review).
+# Intent (owner):
+# - minor/patch: grouped noise reduction; CI-green path may automerge later
+# - major: STILL open as separate PRs so we learn "what could upgrade"
+#   → never auto-merge; Multica/Hermes verification against this repo's stack
+# - Do NOT blanket-ignore semver-major (that hides useful signals)
+# Security majors also arrive via security updates path.
 
 updates:
   - package-ecosystem: npm
@@ -12,16 +15,16 @@ updates:
       day: monday
       time: "09:00"
       timezone: Asia/Seoul
-    open-pull-requests-limit: 5
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 8
+    # No ignore semver-major — majors open one-PR-per-dep (not in minor group).
     commit-message:
       prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
-      - "automerge-candidate"
+      # automerge-candidate only meaningful for minor/patch; majors share this entry's
+      # labels in GitHub Dependabot, so we omit it here. Merge bots must use semver
+      # title parsing (from X to Y) / Multica major review, not this label alone.
     groups:
       npm-minor-and-patch:
         applies-to: version-updates
@@ -35,15 +38,11 @@ updates:
       time: "09:00"
       timezone: Asia/Seoul
     open-pull-requests-limit: 5
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "ci"
       include: "scope"
     labels:
       - "dependencies"
-      - "automerge-candidate"
     groups:
       gha-minor-and-patch:
         applies-to: version-updates


### PR DESCRIPTION
## 요약
Dependabot **major를 숨기지 않습니다.** minor/patch는 그룹으로, major는 개별 PR로 열어 “올릴 수 있는 버전” 신호로 씁니다. 자동 병합은 major에 적용하지 않습니다.

## 목표 · 이유
- 이전 #80의 전면 `semver-major` ignore는 “major도 알려주면 좋다”는 의도와 반대였음.
- Dependabot은 프로젝트 맞춤 지능이 약함 → **신호(PR) + Multica 검증**이 현실적 모델.
- minor/patch만 묶어서 노이즈를 줄이고, major는 패키지별 PR로 검토.

## 변경 사항
- major ignore 제거
- minor/patch group 유지
- `automerge-candidate` 라벨 제거 (ecosystem entry 라벨이 major에도 붙는 GitHub 한계)
- 병합 판정은 title semver / Multica major review에 의존

## 범위 밖
- 기존 open major(#57 등) 머지/닫기
- 패키지별 allowlist (원하면 후속)

## 위험
- Risk tier: T1
- major PR이 다시 열림 → 의도됨. 자동 병합 금지 유지.

## 체크리스트
- [x] major 신호 복구
- [x] minor/patch 그룹 유지
- [x] automerge 라벨로 major를 속이지 않음
