### PR TITLE
chore: lockfile Prettier 제외

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -11,6 +11,11 @@ module.exports = {
   '*.md': ['prettier --write'],
   'blog/**/*.md': ['prettier --write'],
 
-  // JSON/YAML files
-  '*.{json,yaml,yml}': ['prettier --write'],
+  // JSON/YAML files — exclude package manager lockfiles
+  '*.{json,yaml,yml}': (filenames) => {
+    const files = filenames.filter(
+      (f) => !/(^|\/)(pnpm-lock\.yaml|package-lock\.json|yarn\.lock)$/.test(f),
+    )
+    return files.length ? [`prettier --write ${files.join(' ')}`] : []
+  },
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,8 @@ coverage
 
 # Ignore all HTML files:
 **/*.html
+
+# Package manager lockfiles (do not Prettier-rewrite; breaks minimal diffs / can churn YAML)
+pnpm-lock.yaml
+package-lock.json
+yarn.lock


### PR DESCRIPTION
## Summary
- `.prettierignore`에 `pnpm-lock.yaml` 등 lockfile 추가
- `.lintstagedrc.js` YAML/JSON 훅에서 lockfile 제외

## Why
Deploy 복구 PR에서 husky Prettier가 lockfile 전체를 재작성해 diff가 불필요하게 커짐.

## Verification
- config-only change